### PR TITLE
fix typos in specificatin/trace/

### DIFF
--- a/specification/specification/trace/sdk.md
+++ b/specification/specification/trace/sdk.md
@@ -758,7 +758,7 @@ an interface like the java example below (name of the interface MAY be
 extension points for two methods, one to generate a `SpanId` and one for `TraceId`.
 -->
 
-SDKは、以下のJavaの例のようなインターフェースのカスタム実装を可能にすることで、この機能を提供してもかまいません(インターフェースの名前は`IdGenerator`でもよく(MAY)、メソッドの名前は[SpanContext](./api.md#retrieving-the-traceid-and-spanid)と一致しなければなりません(MUST))。
+SDKは、以下のJavaの例のようなインターフェースのカスタム実装を可能にすることで、この機能を提供しても構いません(インターフェースの名前は`IdGenerator`でも構いませんが(MAY)、メソッドの名前は[SpanContext](./api.md#retrieving-the-traceid-and-spanid)と一致しなければなりません(MUST))。
 
 <!--
 ```java
@@ -833,21 +833,6 @@ in the SDK:
 -->
 
 以下の図は、`SpanProcessor`とSDKの他のコンポーネントとの関係を示しています。
-
-<!--
-  +-----+--------------+   +-------------------------+   +-------------------+
-  |     |              |   |                         |   |                   |
-  |     |              |   | Batching Span Processor |   |    SpanExporter   |
-  |     |              +---> Simple Span Processor   +--->  (JaegerExporter) |
-  |     |              |   |                         |   |                   |
-  | SDK | Span.start() |   +-------------------------+   +-------------------+
-  |     | Span.end()   |
-  |     |              |
-  |     |              |
-  |     |              |
-  |     |              |
-  +-----+--------------+
--->
 
 ```
   +-----+--------------+   +-------------------------+   +-------------------+

--- a/specification/specification/trace/semantic_conventions/messaging.md
+++ b/specification/specification/trace/semantic_conventions/messaging.md
@@ -325,7 +325,7 @@ Furthermore, it is strongly recommended to add the [`net.transport`][] attribute
 These attributes should be set to the broker to which the message is sent/from which it is received.
 -->
 
-さらに、[ネットワーク属性][]の`net.peer.port`を推奨します。さらに、[net.transport`][]属性を追加し、特にプロセス中のキューイングシステム([Hangfire][]など)の場合は、そのガイドラインに従うことを強く推奨します。これらの属性には、メッセージの送信先/受信先のブローカーを設定する必要があります。
+さらに、[ネットワーク属性][]の`net.peer.port`を推奨します。さらに、[`net.transport`][]属性を追加し、特にプロセス中のキューイングシステム([Hangfire][]など)の場合は、そのガイドラインに従うことを強く推奨します。これらの属性には、メッセージの送信先/受信先のブローカーを設定する必要があります。
 
 <!--
 [network attributes]: span-general.md#general-network-connection-attributes
@@ -365,7 +365,7 @@ Even though in that case one might think that the processing span's kind should 
 Instead span kind should be set to either `CONSUMER` or `SERVER` according to the rules defined above.
 -->
 
-_receive_Spanはメッセージの受信にかかった時間を追跡し、_process_Spanはメッセージの処理にかかった時間を追跡するのに使います。なお、`messaging.operation` = `process` である1つまたは複数のSpanは、`messaging.operation` = `receive` のSpanの子であることが多いです。メッセージの受信と処理の区別は、必ずしも特別な関心事ではなく、フレームワークの中に隠されていることもあるので(上記の[メッセージ消費](#メッセージ消費)のセクションを参照)、この属性は省くことができます。特にバッチ受信やバッチ処理(後述の[バッチ受信](#バッチ受信)や[バッチ処理](#バッチ処理)の例を参照)では、この属性は設定されるべきです(SHOULD)。この場合、処理Spanのkindを`INTERNAL`にすべきだと考えるかもしれませんが、そのkindは使用してはいけません(MUST NOT)。代わりに、Spanのkindは、上記で定義されたルールに従って、`CONSUMER`または`SERVER`のいずれかに設定する必要があります。
+_receive_ Spanはメッセージの受信にかかった時間を追跡し、_process_ Spanはメッセージの処理にかかった時間を追跡するのに使います。なお、`messaging.operation` = `process` である1つまたは複数のSpanは、`messaging.operation` = `receive` のSpanの子であることが多いです。メッセージの受信と処理の区別は、必ずしも特別な関心事ではなく、フレームワークの中に隠されていることもあるので(上記の[メッセージ消費](#メッセージ消費)のセクションを参照)、この属性は省くことができます。特にバッチ受信やバッチ処理(後述の[バッチ受信](#バッチ受信)や[バッチ処理](#バッチ処理)の例を参照)では、この属性は設定されるべきです(SHOULD)。この場合、処理Spanのkindを`INTERNAL`にすべきだと考えるかもしれませんが、そのkindは使用してはいけません(MUST NOT)。代わりに、Spanのkindは、上記で定義されたルールに従って、`CONSUMER`または`SERVER`のいずれかに設定する必要があります。
 
 <!--
 ### Attributes specific to certain messaging systems
@@ -384,7 +384,7 @@ In RabbitMQ, the destination is defined by an _exchange_ and a _routing key_.
 `messaging.destination` MUST be set to the name of the exchange. This will be an empty string if the default exchange is used.
 -->
 
-RabbitMQでは、宛先は_exchange_と_routing key_で定義されます。`messaging.destination`には、Exchangeの名前を設定しなければなりません(MUST)。デフォルトの取引所を使用する場合は、空の文字列になります。
+RabbitMQでは、宛先は _exchange_ と _routing key_ で定義されます。`messaging.destination`には、Exchangeの名前を設定しなければなりません(MUST)。デフォルトの取引所を使用する場合は、空の文字列になります。
 
 
 <!-- semconv messaging.rabbitmq -->

--- a/specification/specification/trace/semantic_conventions/rpc.md
+++ b/specification/specification/trace/semantic_conventions/rpc.md
@@ -76,7 +76,7 @@ Remote procedure calls can only be represented with these semantic conventions, 
 The _span name_ MUST be the full RPC method name formatted as:
 -->
 
-_span name_は、以下のようにフォーマットされた完全なRPCメソッド名でなければなりません(MUST)。
+_span name_ は、以下のようにフォーマットされた完全なRPCメソッド名でなければなりません(MUST)。
 
 ```
 $package.$service/$method

--- a/specification/specification/trace/semantic_conventions/span-general.md
+++ b/specification/specification/trace/semantic_conventions/span-general.md
@@ -157,7 +157,7 @@ Examples of `peer.service` that users may specify:
 ## General identity attributes
 -->
 
-## 一般的なアイデンティ属性
+## 一般的なアイデンティティ属性
 
 <!--
 These attributes may be used for any operation with an authenticated and/or authorized enduser.


### PR DESCRIPTION
- fix typos
- delete commented out figure in `specification/specification/trace/sdk.md` because it can not be parsed as commented out.